### PR TITLE
Fixes for page titles

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -7,7 +7,7 @@
 
     <title>
       {{ block "title" . }}
-        <!-- individual page title – site title -->
+        {{/* individual page title – site title */}}
         {{ .Title }} – {{ .Site.Title }}
       {{ end }}
     </title>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -8,7 +8,7 @@
     <title>
       {{ block "title" . }}
         {{/* individual page title – site title */}}
-        {{ .Title }} – {{ .Site.Title }}
+        {{ with .Title }}{{ . }} – {{ end }}{{ .Site.Title }}
       {{ end }}
     </title>
 


### PR DESCRIPTION
The comment at https://github.com/sparktrail/sparktrail.org/blob/1659b3b60e5d08e427f9a649f467ec7bb9a69a8b/layouts/_default/baseof.html#L10 was rendering into the title.

The title will now omit the `–` in the title if there is no page title (only displaying the site title).